### PR TITLE
fix `npm start` bug

### DIFF
--- a/smart-home-provider/cloud/auth-provider.js
+++ b/smart-home-provider/cloud/auth-provider.js
@@ -20,6 +20,7 @@ const Auth = {};
 const authstore = require('./datastore').Auth;
 const util = require('util');
 const session = require('express-session');
+const path = require('path');
 
 Auth.getAccessToken = function (request) {
   return request.headers.authorization ? request.headers.authorization.split(' ')[1] : null;
@@ -193,7 +194,7 @@ Auth.registerAuth = function (app) {
   });
 
   app.set('view engine', 'ejs');
-
+  app.set('views', path.join(__dirname, 'views'));
   // Get login.
   app.get('/login', function (req, res) {
     return login(req, res);

--- a/smart-home-provider/cloud/smart-home-provider-cloud.js
+++ b/smart-home-provider/cloud/smart-home-provider-cloud.js
@@ -23,6 +23,7 @@ const google_ha = require('./../smart-home-app');
 const datastore = require('./datastore');
 const authProvider = require('./auth-provider');
 const config = require('./config-provider');
+const path = require('path');
 
 const app = express();
 app.use(morgan('dev'));
@@ -318,9 +319,11 @@ app.get('/getauthcode', function (req, resp) {
       '');
   }
 });
-app.use('/frontend', express.static('../frontend'));
-app.use('/frontend/', express.static('../frontend'));
-app.use('/', express.static('../frontend'));
+
+const frontendPath = path.join(__dirname, '../frontend');
+app.use('/frontend', express.static(frontendPath));
+app.use('/frontend/', express.static(frontendPath));
+app.use('/', express.static(frontendPath));
 
 app.smartHomeSync = function (uid) {
   // console.log('smartHomeSync');


### PR DESCRIPTION
When I run `npm start` in `smart-home-provider/` folder, the
`localhost:3000` will be `404`, I modified the static files path to
`path.join(__dirname, '<static files relative path>')`